### PR TITLE
Video streaming improvments

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1373,7 +1373,7 @@
                   <param index="2">Number of images to capture total - 0 for unlimited capture</param>
                   <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
                   <param index="4">WIP: Resolution horizontal in pixels</param>
-                  <param index="5">WIP: Resolution horizontal in pixels</param>
+                  <param index="5">WIP: Resolution vertical in pixels</param>
                   <param index="6">WIP: Camera ID</param>
               </entry>
 
@@ -1396,7 +1396,7 @@
                   <param index="2">Frames per second</param>
                   <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
                   <param index="4">WIP: Resolution horizontal in pixels</param>
-                  <param index="5">WIP: Resolution horizontal in pixels</param>
+                  <param index="5">WIP: Resolution vertical in pixels</param>
               </entry>
 
               <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1407,6 +1407,13 @@
                   <param index="2">Reserved</param>
               </entry>
 
+              <entry value="2502" name="MAV_CMD_REQUEST_VIDEO_STREAM_TARGET">
+                  <description>WIP: Request video stream target (VIDEO_STREAM_TARGET)</description>
+                  <param index="1">1: Request video stream target</param>
+                  <param index="2">Camera ID</param>
+                  <param index="3">Reserved (all remaining params)</param>
+              </entry>
+
               <entry value="2510" name="MAV_CMD_LOGGING_START">
                    <description>Request to start streaming logging data over MAVLink (see also LOGGING_DATA message)</description>
                    <param index="1">Format: 0: ULog</param>
@@ -3942,6 +3949,21 @@
                <field type="uint8_t" name="target_system">system ID of the target</field>
                <field type="uint8_t" name="target_component">component ID of the target</field>
                <field type="uint16_t" name="sequence">sequence number (must match the one in LOGGING_DATA_ACKED)</field>
+          </message>
+
+          <message id="269" name="VIDEO_STREAM_TARGET">
+            <description>WIP: Information about a video stream target</description>
+            <field type="uint8_t" name="target_system">system ID of the target</field>
+            <field type="uint8_t" name="target_component">component ID of the target</field>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
+            <field type="char[45]" name="ip">Video stream target ip address</field>
+            <field type="uint16_t" name="port">Video stream target port</field>
+          </message>
+          <message id="270" name="SET_VIDEO_STREAM_TARGET">
+            <description>WIP: Message that sets the video stream target</description>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
+            <field type="char[45]" name="ip">Video stream target ip address</field>
+            <field type="uint16_t" name="port">Video stream target port</field>
           </message>
     </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3862,6 +3862,7 @@
             <field type="uint8_t" name="mode_id">Reserved for a camera mode ID</field>
             <field type="uint8_t" name="color_mode_id">Reserved for a color mode ID</field>
             <field type="uint8_t" name="image_format_id">Reserved for image format ID</field>
+            <field type="uint8_t" name="video_format_id">Reserved for video format ID</field>
         </message>
         <message id="261" name="STORAGE_INFORMATION">
             <description>WIP: Information about a storage medium</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1397,6 +1397,8 @@
                   <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
                   <param index="4">WIP: Resolution horizontal in pixels</param>
                   <param index="5">WIP: Resolution vertical in pixels</param>
+                  <param index="6">WIP: Bit rate (0 for auto)</param>
+                  <param index="7">WIP: Video image rotation clockwise (0-359 degrees)</param>
               </entry>
 
               <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">
@@ -3884,6 +3886,8 @@
             <field type="uint16_t" name="image_resolution_v">Image resolution in pixels vertical</field>
             <field type="uint16_t" name="video_resolution_h">Video resolution in pixels horizontal</field>
             <field type="uint16_t" name="video_resolution_v">Video resolution in pixels vertical</field>
+            <field type="uint64_t" name="video_bitrate">Video bit rate in bits per second</field>
+            <field type="uint16_t" name="video_rotation">Video image rotation clockwise in degrees</field>
         </message>
         <message id="263" name="CAMERA_IMAGE_CAPTURED">
             <description>WIP: Information about a captured image</description>


### PR DESCRIPTION
This PR continues work on messages for video streaming.
Add following:
1. 2 new parameters for video: ```bit rate``` and ```video image rotation```
2. new parameter ```video format ID```
3. messages for setting parameters of video streaming target address ```VIDEO_STREAM_TARGET```
4. command for request this options ```MAV_CMD_REQUEST_VIDEO_STREAM_TARGET```
5. fix some errors
